### PR TITLE
Make 1.6 compat, and fix build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,13 +24,13 @@ tempdir = "0.3.4"
 regex = "0.1.60"
 serde = "0.7.0"
 serde_json = "0.7.0"
-serde_macros = { version = "0.7.0", optional = true }
+serde_macros = { version = "0.7.2", optional = true }
 itertools = "0.4.11"
 
 
 [build-dependencies]
-serde_codegen = { version = "0.7.0", optional = true }
-syntex = "0.30.0"
+serde_codegen = { version = "0.7.2", optional = true }
+syntex = "0.31.0"
 itertools = "0.4.11"
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,13 +24,13 @@ tempdir = "0.3.4"
 regex = "0.1.60"
 serde = "0.7.0"
 serde_json = "0.7.0"
-serde_macros = { version = "0.7.2", optional = true }
+serde_macros = { version = "^0.7.2", optional = true }
 itertools = "0.4.11"
 
 
 [build-dependencies]
-serde_codegen = { version = "0.7.2", optional = true }
-syntex = "0.31.0"
+serde_codegen = { version = "^0.7.2", optional = true }
+syntex = "^0.31.0"
 itertools = "0.4.11"
 
 

--- a/src/definitions/destructuring/invoke_arg.rs
+++ b/src/definitions/destructuring/invoke_arg.rs
@@ -85,7 +85,7 @@ impl FromInvokeArg for bool {
     match arg {
       InvokeArgument::None => Ok(false),
       InvokeArgument::String(val) => {
-        match val.as_str() {
+        match val.as_ref() {
           "false" => Ok(false),
           _ => Ok(true)
         }


### PR DESCRIPTION
I have absolutely no idea how the build broke, since we're hardcoded to dependency versions. Alas, this fixes the build.

It also makes it 1.6 compat, because thats the latest version available for nix. Dumb, I know.
