### PR TITLE
WIP: Update step registration to use catch_unwind instead of InvokeResponse

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cucumber"
-version = "0.1.3"
+version = "0.2.3"
 authors = ["Alex McArther <acmcarther@gmail.com>"]
 description = "Tooling for using Cucumber with Rust projects"
 documentation = "https://acmcarther.github.io/cucumber/cucumber/index.html"
@@ -36,3 +36,4 @@ itertools = "0.4.11"
 [[test]]
 name = "cuke"
 path = "./features/cuke.rs"
+harness = false

--- a/examples/calculator/features/step_definitions/calculator_steps.rs
+++ b/examples/calculator/features/step_definitions/calculator_steps.rs
@@ -1,7 +1,4 @@
-use cucumber::{
-  CucumberRegistrar,
-  InvokeResponse
-};
+use cucumber::CucumberRegistrar;
 
 use support::env::CalculatorWorld;
 use calculator::CalculatorCommand;
@@ -9,24 +6,28 @@ use calculator::CalculatorCommand;
 #[allow(dead_code)]
 pub fn register_steps(c: &mut CucumberRegistrar<CalculatorWorld>) {
 
-  Given!(c, "^a clear calculator$", |_, world: &mut CalculatorWorld, _| {
-    world.calculator.clear();
-    InvokeResponse::Success
-  });
+  Given!(c,
+         "^a clear calculator$",
+         |_, world: &mut CalculatorWorld, _| {
+           world.calculator.clear();
+         });
 
   When!(c, "^I begin adding$", |_, world: &mut CalculatorWorld, _| {
     world.last_response = Some(world.calculator.push_command(CalculatorCommand::Add));
-    InvokeResponse::Success
   });
 
-  When!(c, "^I begin subtracting$", |_, world: &mut CalculatorWorld, _| {
-    world.last_response = Some(world.calculator.push_command(CalculatorCommand::Minus));
-    InvokeResponse::Success
-  });
+  When!(c,
+        "^I begin subtracting$",
+        |_, world: &mut CalculatorWorld, _| {
+          world.last_response = Some(world.calculator.push_command(CalculatorCommand::Minus));
+        });
 
-  When!(c, "^I input (-)?(\\d+)$", |_, world: &mut CalculatorWorld, (negate, mut val): (bool, i32)| {
-    if negate { val = -val }
-    world.last_response = Some(world.calculator.push_command(CalculatorCommand::Number(val)));
-    InvokeResponse::Success
-  });
+  When!(c,
+        "^I input (-)?(\\d+)$",
+        |_, world: &mut CalculatorWorld, (negate, mut val): (bool, i32)| {
+          if negate {
+            val = -val
+          }
+          world.last_response = Some(world.calculator.push_command(CalculatorCommand::Number(val)));
+        });
 }

--- a/examples/calculator/features/step_definitions/display_steps.rs
+++ b/examples/calculator/features/step_definitions/display_steps.rs
@@ -1,20 +1,23 @@
-use cucumber::{
-  CucumberRegistrar,
-  InvokeResponse
-};
+use cucumber::CucumberRegistrar;
 use support::env::CalculatorWorld;
 
 #[allow(dead_code)]
 pub fn register_steps(c: &mut CucumberRegistrar<CalculatorWorld>) {
-  Then!(c, "^the (?:next )?result is (-)?(\\d+)$", |_, world: &mut CalculatorWorld, (negate, mut val): (bool, i32)| {
-    if negate { val = -val }
-    InvokeResponse::check_eq(world.calculator.evaluate(), val)
-  });
+  Then!(c,
+        "^the (?:next )?result is (-)?(\\d+)$",
+        |_, world: &mut CalculatorWorld, (negate, mut val): (bool, i32)| {
+          if negate {
+            val = -val
+          }
+          assert_eq!(world.calculator.evaluate(), val)
+        });
 
-  Then!(c, "^the last message includes \"(.*)\"$", |_, world: &mut CalculatorWorld, (message,): (String,)| {
-    match world.last_response {
-      None => InvokeResponse::fail_from_str("No last message"),
-      Some(ref msg) => InvokeResponse::check(msg.to_string().contains(&message))
-    }
-  });
+  Then!(c,
+        "^the last message includes \"(.*)\"$",
+        |_, world: &mut CalculatorWorld, (message,): (String,)| {
+          match world.last_response {
+            None => panic!("No last message"),
+            Some(ref msg) => assert!(msg.to_string().contains(&message)),
+          }
+        });
 }

--- a/examples/calculator/features/support/env.rs
+++ b/examples/calculator/features/support/env.rs
@@ -1,18 +1,15 @@
-use calculator::{
-  Calculator,
-  CalculatorPushResponse
-};
+use calculator::{Calculator, CalculatorPushResponse};
 
 pub struct CalculatorWorld {
   pub calculator: Calculator,
-  pub last_response: Option<CalculatorPushResponse>
+  pub last_response: Option<CalculatorPushResponse>,
 }
 
 impl CalculatorWorld {
   pub fn new() -> CalculatorWorld {
     CalculatorWorld {
       calculator: Calculator::new(),
-      last_response: None
+      last_response: None,
     }
   }
 }

--- a/features/cuke.rs
+++ b/features/cuke.rs
@@ -2,24 +2,17 @@
 extern crate cucumber;
 
 extern crate tempdir;
+extern crate itertools;
 
 mod step_definitions;
 mod support;
 
 use support::env::CucumberWorld;
 
-use step_definitions::{
-  project_steps
-};
+use step_definitions::project_steps;
 
-#[test]
 fn cuke() {
-  cucumber::start(
-    CucumberWorld::new(),
-    &[
-      &project_steps::register_steps,
-    ]
-  );
+  cucumber::start(CucumberWorld::new(), &[&project_steps::register_steps]);
 }
 
 fn main() {

--- a/features/feature_features/argument_types.feature
+++ b/features/feature_features/argument_types.feature
@@ -5,29 +5,29 @@ Feature: Step argument type inference
     And the steps
       """
         Given!(c, "^a step with optional arg:( optional)?$", |_, _, (b,): (bool,)| {
-          InvokeResponse::check(b)
+          assert!(b);
         });
 
         Given!(c, "^a step with number arg: (\\d+)$", |_, _, (u,): (u32,)| {
-          InvokeResponse::check_eq(u, 10)
+          assert_eq!(u, 10);
         });
 
         Given!(c, "^a step with string arg: \"(.*)\"$", |_, _, (s,): (String,)| {
-          InvokeResponse::check_eq(s, "test".to_owned())
+          assert_eq!(s, "test".to_owned());
         });
 
         Given!(c, "^a step with docstring arg:$", |_, _, (s,): (String,)| {
-          InvokeResponse::check_eq(s, "docstring".to_owned())
+          assert_eq!(s, "docstring".to_owned());
         });
 
         Given!(c, "^a step with table arg:$", |_, _, (t,): (Vec<Vec<String>>,)| {
-          InvokeResponse::check_eq(t, vec![vec!["1".to_owned(), "2".to_owned(), "3".to_owned()]])
+          assert_eq!(t, vec![vec!["1".to_owned(), "2".to_owned(), "3".to_owned()]]);
         });
 
         Given!(c, "^a step with multiple args:( optional)? (\\d+)$", |_, _, (b, u, t): (bool, u32, Vec<Vec<String>>)| {
-          InvokeResponse::check_eq(b, true)
-            .and(InvokeResponse::check_eq(u, 20))
-            .and(InvokeResponse::check_eq(t, vec![vec!["1".to_owned()], vec!["2".to_owned()], vec!["3".to_owned()]]))
+          assert_eq!(b, true);
+          assert_eq!(u, 20);
+          assert_eq!(t, vec![vec!["1".to_owned()], vec!["2".to_owned()], vec!["3".to_owned()]]);
         });
       """
     Then the project compiles

--- a/features/feature_features/calling_steps.feature
+++ b/features/feature_features/calling_steps.feature
@@ -5,11 +5,11 @@ Feature: Calling steps within steps
     And the steps
       """
         When!(c, "^I get invoked indirectly$", |_, _, _| {
-          InvokeResponse::fail_from_str("Indirect step got invoked!")
+          panic!("Indirect step got invoked!");
         });
 
         When!(c, "^I invoke a step indirectly$", |cuke: &Cucumber<u32>, world: &mut u32, _| {
-          cuke.invoke("I get invoked indirectly", world, None)
+          cuke.invoke("I get invoked indirectly", world, None);
         });
       """
     Then the project compiles

--- a/features/feature_features/executing.feature
+++ b/features/feature_features/executing.feature
@@ -5,27 +5,24 @@ Feature: Executing Features
     And the steps
       """
         Given!(c, "^a passing given step$", |_, _, _| {
-          InvokeResponse::Success
         });
 
         When!(c, "^a passing when step$", |_, _, _| {
-          InvokeResponse::Success
         });
 
         Then!(c, "^a passing then step$", |_, _, _| {
-          InvokeResponse::Success
         });
 
         Given!(c, "^a failing given step$", |_, _, _| {
-          InvokeResponse::fail_from_str("Given Step Failed")
+          panic!("Given Step Failed");
         });
 
         When!(c, "^a failing when step$", |_, _, _| {
-          InvokeResponse::fail_from_str("When Step Failed")
+          panic!("When Step Failed");
         });
 
         Then!(c, "^a failing then step$", |_, _, _| {
-          InvokeResponse::fail_from_str("Then Step Failed")
+          panic!("Then Step Failed");
         });
       """
     Then the project compiles

--- a/features/feature_features/explicit_failures.feature
+++ b/features/feature_features/explicit_failures.feature
@@ -1,0 +1,20 @@
+Feature: Explicit failures
+  Background:
+    Given a project if I don't already have one
+    And the steps
+      """
+        Given!(c, "^an ordinary step$", |c: &Cucumber<u32>, _, _| {
+          c.fail("I just don't want this step to pass");
+        });
+      """
+    Then the project compiles
+
+  Scenario: Evaluating step that explicitly fails
+    When the following feature is executed
+      """
+        Feature: I do a thing
+          Scenario: The thing works
+            Given an ordinary step
+      """
+    Then the feature fails with "I just don't want this step to pass"
+

--- a/features/feature_features/explicit_successes.feature
+++ b/features/feature_features/explicit_successes.feature
@@ -1,0 +1,20 @@
+Feature: Explicit (early) success
+  Background:
+    Given a project if I don't already have one
+    And the steps
+      """
+        Given!(c, "^an ordinary step$", |c: &Cucumber<u32>, _, _| {
+          c.succeed_immediately();
+          panic!("Unreachable panic!");
+        });
+      """
+    Then the project compiles
+
+  Scenario: Evaluating step that explicitly fails
+    When the following feature is executed
+      """
+        Feature: I do a thing
+          Scenario: The thing works
+            Given an ordinary step
+      """
+    Then the feature passes with no undefined steps

--- a/features/feature_features/invalid_arguments.feature
+++ b/features/feature_features/invalid_arguments.feature
@@ -6,17 +6,14 @@ Feature: Invalid argument types
       """
         Given!(c, "^a step with non-matching args$", |_, _, (b,): (bool,)| {
           // Not reachable
-          InvokeResponse::Success
         });
 
         Given!(c, "^another step with unparseable table arg:$", |_, _, (s,): (String,)| {
           // Not reachable
-          InvokeResponse::Success
         });
 
         Given!(c, "^another step with unparseable args: \"(.*)\"$", |_, _, (u,): (u32,)| {
           // Not reachable
-          InvokeResponse::Success
         });
       """
     Then the project compiles

--- a/features/feature_features/passing_arguments.feature
+++ b/features/feature_features/passing_arguments.feature
@@ -1,0 +1,27 @@
+Feature: Invalid argument types
+
+  Background:
+    Given a project if I don't already have one
+    And the steps
+      """
+        Given!(c, "^I just explode$", |c: &Cucumber<u32>, _, _| {
+          c.fail("Should not have invoked this scenario");
+        });
+
+        Given!(c, "^I run normally$", |_, _, _| {
+        });
+      """
+    Then the project compiles
+
+  Scenario: Evaluating step with missing args
+    When the following feature is executed with "-t @RunOnly"
+      """
+        Feature: I do a thing
+          Scenario: This will explode
+            Given I just explode
+
+          @RunOnly
+          Scenario: I don't explode
+            Given I run normally
+      """
+    Then the feature passes with no undefined steps

--- a/features/feature_features/pending_steps.feature
+++ b/features/feature_features/pending_steps.feature
@@ -4,8 +4,8 @@ Feature: Pending Steps
     Given a project if I don't already have one
     And the steps
       """
-        Given!(c, "^a pending step$", |_, _, _| {
-          InvokeResponse::Pending("Test step is pending".to_owned())
+      Given!(c, "^a pending step$", |c: &Cucumber<u32>, _, _| {
+          c.pending("Test step is pending");
         });
       """
     Then the project compiles

--- a/features/step_definitions/project_steps.rs
+++ b/features/step_definitions/project_steps.rs
@@ -1,8 +1,4 @@
-use cucumber::{
-  Cucumber,
-  CucumberRegistrar,
-  InvokeResponse
-};
+use cucumber::{Cucumber, CucumberRegistrar, InvokeArgument};
 use support::env::CucumberWorld;
 use support::fs;
 
@@ -12,97 +8,127 @@ pub fn register_steps(c: &mut CucumberRegistrar<CucumberWorld>) {
     match fs::create_project() {
       Ok(current_project) => {
         world.current_project = Some(current_project);
-        InvokeResponse::Success
       },
-      Err(ref err) => InvokeResponse::fail_from_str(&format!("Failed to create project {}", err))
+      Err(ref err) => panic!("Failed to create project {}", err),
     }
   });
 
-  Given!(c, "^a project if I don't already have one$", |cuke: &Cucumber<CucumberWorld>, world: &mut CucumberWorld, _| {
-    match world.current_project {
-      Some(_) => InvokeResponse::Success,
-      None => cuke.invoke("a project", world, None)
-    }
-  });
+  Given!(c,
+         "^a project if I don't already have one$",
+         |cuke: &Cucumber<CucumberWorld>, world: &mut CucumberWorld, _| {
+           match world.current_project {
+             None => cuke.invoke("a project", world, None),
+             _ => {},
+           }
+         });
 
-  Given!(c, "^the steps$", |_, world: &mut CucumberWorld, (step_set,): (String,)| {
+  Given!(c,
+         "^the steps$",
+         |_, world: &mut CucumberWorld, (step_set,): (String,)| {
     match world.current_project {
-      None => return InvokeResponse::fail_from_str("There was no project to add steps to"),
+      None => return panic!("There was no project to add steps to"),
       Some(ref mut project) => {
         project.set_steps(&step_set);
-        InvokeResponse::Success
-      }
+      },
     }
   });
 
-  Then!(c, "^the project compiles$", |_, world: &mut CucumberWorld, _| {
+  Then!(c,
+        "^the project compiles$",
+        |_, world: &mut CucumberWorld, _| {
     match world.current_project {
-      None => return InvokeResponse::fail_from_str("There was no project to compile"),
+      None => return panic!("There was no project to compile"),
       Some(ref mut project) => {
         match project.compile() {
-          Err(err) => InvokeResponse::fail_from_str(&format!("The project failed to compile with: {}", err)),
-          Ok(_) => InvokeResponse::Success
+          Err(err) => panic!("The project failed to compile with: {}", err),
+          _ => {},
         }
-      }
+      },
     }
   });
 
-  When!(c, "^the following feature is executed$", |_, world: &mut CucumberWorld, (scenario,): (String,)| {
+  When!(c,
+        "^the following feature is executed$",
+        |c: &Cucumber<CucumberWorld>, world: &mut CucumberWorld, (scenario,): (String,)| {
+          c.invoke("the following feature is executed with \"\"",
+                   world,
+                   Some(InvokeArgument::String(scenario)));
+        });
+
+  When!(c,
+        "^the following feature is executed with \"(.*)\"$",
+        |_, world: &mut CucumberWorld, (args, scenario): (String, String)| {
     match world.current_project {
-      None => return InvokeResponse::fail_from_str("There was no project to compile"),
+      None => return panic!("There was no project to compile"),
       Some(ref mut project) => {
-        let result = project.execute_feature(&scenario);
+        let result = project.execute_feature(&scenario, &args);
         world.execute_result = Some(result);
-        InvokeResponse::Success
-      }
+      },
     }
 
   });
 
-  Then!(c, "^the feature passes with no undefined steps$", |cuke: &Cucumber<CucumberWorld>, world: &mut CucumberWorld, _| {
-    cuke.invoke("the feature passes", world, None)
-      .and(cuke.invoke("the feature reports no undefined steps", world, None))
-  });
 
-  Then!(c, "^the feature passes$", |_, world: &mut CucumberWorld, _| {
+  Then!(c,
+        "^the feature passes with no undefined steps$",
+        |cuke: &Cucumber<CucumberWorld>, world: &mut CucumberWorld, _| {
+          cuke.invoke("the feature passes", world, None);
+          cuke.invoke("the feature reports no undefined steps", world, None);
+        });
+
+  Then!(c,
+        "^the feature passes$",
+        |_, world: &mut CucumberWorld, _| {
     match world.execute_result {
-      None => InvokeResponse::fail_from_str("Expected there to be an execute result but there wasn't one"),
-      Some(Err(ref err)) => InvokeResponse::fail_from_str(&format!("Expected scenario to pass but it failed with {}", err)),
-      _ => InvokeResponse::Success
+      None => panic!("Expected there to be an execute result but there wasn't one"),
+      Some(Err(ref err)) => panic!("Expected scenario to pass but it failed with {}", err),
+      _ => {},
     }
   });
 
-  Then!(c, "^the feature fails with \"([^\"]*)\"$", |_, world: &mut CucumberWorld, (fail_msg,): (String,)| {
+  Then!(c,
+        "^the feature fails with \"([^\"]*)\"$",
+        |_, world: &mut CucumberWorld, (fail_msg,): (String,)| {
     match world.execute_result {
-      None => InvokeResponse::fail_from_str("Expected there to be an execute result but there wasn't one"),
-      Some(Ok(_)) => InvokeResponse::fail_from_str("Expected scenario to fail but it passed"),
-      Some(Err(ref err)) => {
-        InvokeResponse::expect(err.contains(&fail_msg), &format!("expected to find {} in error message: {}", fail_msg, err))
-      }
+      None => panic!("Expected there to be an execute result but there wasn't one"),
+      Some(Ok(_)) => panic!("Expected scenario to fail but it passed"),
+      Some(Err(ref err)) => assert!(err.contains(&fail_msg)),
     }
   });
 
-  Then!(c, "^the feature reports an undefined step$", |_, world: &mut CucumberWorld, _| {
+  Then!(c,
+        "^the feature reports an undefined step$",
+        |_, world: &mut CucumberWorld, _| {
     match world.execute_result {
-      None => InvokeResponse::fail_from_str("Expected there to be an execute result but there wasn't one"),
-      Some(Err(_)) => InvokeResponse::fail_from_str("Expected scenario to pass (to retrieve an undefined step) but it failed"),
-      Some(Ok(ref output)) => InvokeResponse::expect(output.contains("1 undefined"), "Expected scenario output to contain exactly one undefined step")
+      None => panic!("Expected there to be an execute result but there wasn't one"),
+      Some(Err(_)) => {
+        panic!("Expected scenario to pass (to retrieve an undefined step) but it failed")
+      },
+      Some(Ok(ref output)) => assert!(output.contains("1 undefined")),
     }
   });
 
-  Then!(c, "^the feature reports no undefined steps$", |_, world: &mut CucumberWorld, _| {
+  Then!(c,
+        "^the feature reports no undefined steps$",
+        |_, world: &mut CucumberWorld, _| {
     match world.execute_result {
-      None => InvokeResponse::fail_from_str("Expected there to be an execute result but there wasn't one"),
-      Some(Err(_)) => InvokeResponse::fail_from_str("Expected scenario to pass (to retrieve an undefined step) but it failed"),
-      Some(Ok(ref output)) => InvokeResponse::expect(!output.contains(" undefined"), &format!("Expected scenario output to contain no undefined steps, but it contained some: {}", output))
+      None => panic!("Expected there to be an execute result but there wasn't one"),
+      Some(Err(_)) => {
+        panic!("Expected scenario to pass (to retrieve an undefined step) but it failed")
+      },
+      Some(Ok(ref output)) => assert!(!output.contains(" undefined")),
     }
   });
 
-  Then!(c, "^the feature reports a pending step$", |_, world: &mut CucumberWorld, _| {
+  Then!(c,
+        "^the feature reports a pending step$",
+        |_, world: &mut CucumberWorld, _| {
     match world.execute_result {
-      None => InvokeResponse::fail_from_str("Expected there to be an execute result but there wasn't one"),
-      Some(Err(_)) => InvokeResponse::fail_from_str("Expected scenario to pass (to retrieve a pending step) but it failed"),
-      Some(Ok(ref output)) => InvokeResponse::expect(output.contains("Test step is pending"), "Expected scenario output to contain pending step")
+      None => panic!("Expected there to be an execute result but there wasn't one"),
+      Some(Err(_)) => {
+        panic!("Expected scenario to pass (to retrieve a pending step) but it failed")
+      },
+      Some(Ok(ref output)) => assert!(output.contains("Test step is pending")),
     }
   });
 }

--- a/features/support/env.rs
+++ b/features/support/env.rs
@@ -5,6 +5,9 @@ pub struct CucumberWorld {
 
 impl CucumberWorld {
   pub fn new() -> CucumberWorld {
-    CucumberWorld { current_project: None, execute_result: None }
+    CucumberWorld {
+      current_project: None,
+      execute_result: None,
+    }
   }
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,5 @@
+match_block_trailing_comma = true
+report_fixme = "always"
+tab_spaces = 2
+reorder_imports = true
+wrap_comments = true

--- a/src/definitions/destructuring/invoke_arg.rs
+++ b/src/definitions/destructuring/invoke_arg.rs
@@ -16,7 +16,9 @@ pub trait FromInvokeArg: Sized {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct ImproperInvokeArgError { _priv: () }
+pub struct ImproperInvokeArgError {
+  _priv: (),
+}
 
 // NOTE: This is a stopgap for impl specialization
 //   The underlying issue is that FromInvokeArg can't be impld for all FromStr
@@ -39,7 +41,9 @@ macro_rules! impl_for_from_str {
   }
 }
 
-impl <T> FromInvokeArg for Option<T> where T: FromInvokeArg {
+impl<T> FromInvokeArg for Option<T>
+  where T: FromInvokeArg
+{
   type Err = ImproperInvokeArgError;
 
   fn from_invoke_arg(arg: InvokeArgument) -> Result<Option<T>, ImproperInvokeArgError> {
@@ -48,9 +52,9 @@ impl <T> FromInvokeArg for Option<T> where T: FromInvokeArg {
       e @ InvokeArgument::String(_) => {
         T::from_invoke_arg(e)
           .map(|r| Some(r))
-          .map_err(|_| ImproperInvokeArgError { _priv: ()})
+          .map_err(|_| ImproperInvokeArgError { _priv: () })
       },
-      _ => Err(ImproperInvokeArgError { _priv: () })
+      _ => Err(ImproperInvokeArgError { _priv: () }),
     }
   }
 }
@@ -72,12 +76,13 @@ impl FromInvokeArg for String {
   fn from_invoke_arg(arg: InvokeArgument) -> Result<String, ImproperInvokeArgError> {
     match arg {
       InvokeArgument::String(val) => Ok(val),
-      _ => Err(ImproperInvokeArgError { _priv: () })
+      _ => Err(ImproperInvokeArgError { _priv: () }),
     }
   }
 }
 
-// NOTE: Rules for booleans are a bit unconventional to facilitiate easy use of optional captures:
+// NOTE: Rules for booleans are a bit unconventional to facilitiate easy use of
+// optional captures:
 impl FromInvokeArg for bool {
   type Err = ImproperInvokeArgError;
 
@@ -87,10 +92,10 @@ impl FromInvokeArg for bool {
       InvokeArgument::String(val) => {
         match val.as_ref() {
           "false" => Ok(false),
-          _ => Ok(true)
+          _ => Ok(true),
         }
       },
-      _ => Err(ImproperInvokeArgError { _priv: () })
+      _ => Err(ImproperInvokeArgError { _priv: () }),
     }
   }
 }
@@ -101,7 +106,7 @@ impl FromInvokeArg for Vec<Vec<String>> {
   fn from_invoke_arg(arg: InvokeArgument) -> Result<Vec<Vec<String>>, ImproperInvokeArgError> {
     match arg {
       InvokeArgument::Table(val) => Ok(val),
-      _ => Err(ImproperInvokeArgError { _priv: () })
+      _ => Err(ImproperInvokeArgError { _priv: () }),
     }
   }
 }
@@ -113,7 +118,8 @@ mod test {
 
   #[test]
   fn wrong_type_destructure_fails_correctly() {
-    let res: Result<u32, ImproperInvokeArgError> = InvokeArgument::String("hello".to_owned()).destructure();
+    let res: Result<u32, ImproperInvokeArgError> = InvokeArgument::String("hello".to_owned())
+      .destructure();
 
     assert_eq!(res, Err(ImproperInvokeArgError { _priv: () }));
   }
@@ -127,7 +133,8 @@ mod test {
 
   #[test]
   fn table_can_be_destructured() {
-    let res: Vec<Vec<String>> = InvokeArgument::Table(vec![vec!["hello".to_owned()]]).destructure().unwrap();
+    let res: Vec<Vec<String>> =
+      InvokeArgument::Table(vec![vec!["hello".to_owned()]]).destructure().unwrap();
 
     assert_eq!(res, vec![vec!["hello".to_owned()]]);
   }
@@ -137,7 +144,8 @@ mod test {
 
     #[test]
     fn bool_doesnt_parse_from_table() {
-      let res: Result<bool, ImproperInvokeArgError> = InvokeArgument::Table(vec![vec!["hello".to_owned()]]).destructure();
+      let res: Result<bool, ImproperInvokeArgError> =
+        InvokeArgument::Table(vec![vec!["hello".to_owned()]]).destructure();
 
       assert_eq!(res, Err(ImproperInvokeArgError { _priv: () }));
     }

--- a/src/definitions/destructuring/mod.rs
+++ b/src/definitions/destructuring/mod.rs
@@ -1,19 +1,15 @@
 //! Logic for dissassembling Invoke Arguments
 //!
-//! This module is not usually used directly -- rather, its work is handled by the
-//! [try_destructure! macro](../../macro.try_destructure!.html), which in turn is handled mostly by
-//! the [Given!](../../macro.Given!.html), [When!](../../macro.When!.html), and [Then!](../../macro.Then!.html) macros.
+//! This module is not usually used directly -- rather, its work is handled by
+//! the
+//! [try_destructure! macro](../../macro.try_destructure!.html), which in turn
+//! is handled mostly by
+//! the [Given!](../../macro.Given!.html), [When!](../../macro.When!.html), and
+//! [Then!](../../macro.Then!.html) macros.
 
 pub mod invoke_arg;
 pub mod invoke_arg_set;
 
-pub use self::invoke_arg::{
-  FromInvokeArg,
-  Destructurable,
-};
+pub use self::invoke_arg::{Destructurable, FromInvokeArg};
 
-pub use self::invoke_arg_set::{
-  InvokeArgSetError,
-  FromInvokeArgSet,
-  DestructurableSet,
-};
+pub use self::invoke_arg_set::{DestructurableSet, FromInvokeArgSet, InvokeArgSetError};

--- a/src/definitions/registration.rs
+++ b/src/definitions/registration.rs
@@ -1,29 +1,35 @@
 //! Logic for registering step definitions
 
-use state::{Cucumber, Step};
+use state::Cucumber;
 use regex::Regex;
+use event::request::InvokeArgument;
+
+/// A "simpler" api-level step. Panic to fail.
+pub type SimpleStep<World> = Box<Fn(&Cucumber<World>, &mut World, Vec<InvokeArgument>) + Send>;
 
 /// An interface for registering steps
 ///
-/// This is a rough interface, because it requires specifying file and line information manually. Prefer using [the macros](../../index.html#macros).
+/// This is a rough interface, because it requires specifying file and line
+/// information manually. Prefer using [the macros](../../index.html#macros).
 ///
-/// See [WorldRunner](../../runner/struct.WorldRunner.html) for the primary implementer.
+/// See [WorldRunner](../../runner/struct.WorldRunner.html) for the primary
+/// implementer.
 pub trait CucumberRegistrar<World> {
-  fn given(&mut self, file: &str, line: u32, Regex, Step<World>);
-  fn when(&mut self, file: &str, line: u32, Regex, Step<World>);
-  fn then(&mut self, file: &str, line: u32, Regex, Step<World>);
+  fn given(&mut self, file: &str, line: u32, Regex, SimpleStep<World>);
+  fn when(&mut self, file: &str, line: u32, Regex, SimpleStep<World>);
+  fn then(&mut self, file: &str, line: u32, Regex, SimpleStep<World>);
 }
 
-impl <World> CucumberRegistrar<World> for Cucumber<World> {
-  fn given(&mut self, file: &str, line: u32, regex: Regex, step: Step<World>) {
+impl<World> CucumberRegistrar<World> for Cucumber<World> {
+  fn given(&mut self, file: &str, line: u32, regex: Regex, step: SimpleStep<World>) {
     self.insert_step(format!("{}:{}", file, line), regex, step)
   }
 
-  fn when(&mut self, file: &str, line: u32, regex: Regex, step: Step<World>) {
+  fn when(&mut self, file: &str, line: u32, regex: Regex, step: SimpleStep<World>) {
     self.insert_step(format!("{}:{}", file, line), regex, step)
   }
 
-  fn then(&mut self, file: &str, line: u32, regex: Regex, step: Step<World>) {
+  fn then(&mut self, file: &str, line: u32, regex: Regex, step: SimpleStep<World>) {
     self.insert_step(format!("{}:{}", file, line), regex, step)
   }
 }

--- a/src/event/request.rs
+++ b/src/event/request.rs
@@ -1,7 +1,9 @@
 //! Contains requests made by Gherkin interpreter (or Wire Protocol).
 //!
-//! Consumers will interact with [InvokeArgument](./enum.InvokeArgument.html) if using
-//! [Cucumber's](../../state/struct.Cucumber.html) direct invoke capability with tables or
+//! Consumers will interact with [InvokeArgument](./enum.InvokeArgument.html)
+//! if using
+//! [Cucumber's](../../state/struct.Cucumber.html) direct invoke capability
+//! with tables or
 //! docstrings.
 
 #[cfg(feature = "serde_macros")]
@@ -54,13 +56,13 @@ impl Visitor for RequestVisitor {
     match cmd_type {
       None => Err(V::Error::invalid_length(0)),
       Some(command) => {
-        match command.as_ref(){
+        match command.as_ref() {
           "step_matches" => {
             let payload = try!(_visitor.visit::<StepMatchesRequest>());
             try!(_visitor.end());
             match payload {
               None => Err(V::Error::invalid_length(1)),
-              Some(payload) => Ok(Request::StepMatches(payload))
+              Some(payload) => Ok(Request::StepMatches(payload)),
             }
           },
           "invoke" => {
@@ -68,7 +70,7 @@ impl Visitor for RequestVisitor {
             try!(_visitor.end());
             match payload {
               None => Err(V::Error::invalid_length(1)),
-              Some(payload) => Ok(Request::Invoke(payload))
+              Some(payload) => Ok(Request::Invoke(payload)),
             }
           },
           "begin_scenario" => {
@@ -76,7 +78,7 @@ impl Visitor for RequestVisitor {
             try!(_visitor.end());
             match payload {
               None => Ok(Request::BeginScenario(BeginScenarioRequest { tags: Vec::new() })),
-              Some(payload) => Ok(Request::BeginScenario(payload))
+              Some(payload) => Ok(Request::BeginScenario(payload)),
             }
           },
           "end_scenario" => {
@@ -84,7 +86,7 @@ impl Visitor for RequestVisitor {
             try!(_visitor.end());
             match payload {
               None => Ok(Request::EndScenario(EndScenarioRequest { tags: Vec::new() })),
-              Some(payload) => Ok(Request::EndScenario(payload))
+              Some(payload) => Ok(Request::EndScenario(payload)),
             }
           },
           "snippet_text" => {
@@ -92,10 +94,10 @@ impl Visitor for RequestVisitor {
             try!(_visitor.end());
             match payload {
               None => Err(V::Error::invalid_length(1)),
-              Some(payload) => Ok(Request::SnippetText(payload))
+              Some(payload) => Ok(Request::SnippetText(payload)),
             }
           },
-          _ => Err(V::Error::custom("Unknown command type as first value"))
+          _ => Err(V::Error::custom("Unknown command type as first value")),
         }
       },
     }
@@ -104,13 +106,15 @@ impl Visitor for RequestVisitor {
 
 /// The low level type capturing the possible values a step may provide.
 ///
-/// Normal regex arguments as well as docstrings come in the form of the String variant. Conversion
-/// to other types is done at later stages. Tables are represented as `Vec<Vec<String>>`
+/// Normal regex arguments as well as docstrings come in the form of the String
+/// variant. Conversion
+/// to other types is done at later stages. Tables are represented as
+/// `Vec<Vec<String>>`
 #[derive(Eq, PartialEq, Clone, Debug)]
 pub enum InvokeArgument {
   String(String),
   None,
-  Table(Vec<Vec<String>>)
+  Table(Vec<Vec<String>>),
 }
 
 impl InvokeArgument {
@@ -121,7 +125,7 @@ impl InvokeArgument {
   pub fn from_step_arg(arg: StepArg) -> InvokeArgument {
     match arg.val {
       Some(v) => InvokeArgument::String(v),
-      None => InvokeArgument::None
+      None => InvokeArgument::None,
     }
   }
 }
@@ -161,9 +165,10 @@ mod test {
     let res = serde_json::from_str(json);
     match res.unwrap() {
       Request::StepMatches(payload) => {
-        assert_eq!(payload, StepMatchesRequest {name_to_match: "we're all wired".to_owned()})
+        assert_eq!(payload,
+                   StepMatchesRequest { name_to_match: "we're all wired".to_owned() })
       },
-      _ => panic!("result was not StepMatches type")
+      _ => panic!("result was not StepMatches type"),
     }
   }
 
@@ -173,9 +178,13 @@ mod test {
     let res = serde_json::from_str(json);
     match res.unwrap() {
       Request::Invoke(payload) => {
-        assert_eq!(payload, InvokeRequest {id: "1".to_owned(), args: Vec::new()})
+        assert_eq!(payload,
+                   InvokeRequest {
+                     id: "1".to_owned(),
+                     args: Vec::new(),
+                   })
       },
-      _ => panic!("result was not Invoke type")
+      _ => panic!("result was not Invoke type"),
     }
   }
 
@@ -186,25 +195,34 @@ mod test {
     println!("{:?}", res);
     match res.unwrap() {
       Request::Invoke(payload) => {
-        assert_eq!(payload, InvokeRequest {id: "1".to_owned(), args: vec!(InvokeArgument::from_str("wired"))})
+        assert_eq!(payload,
+                   InvokeRequest {
+                     id: "1".to_owned(),
+                     args: vec![InvokeArgument::from_str("wired")],
+                   })
       },
-      _ => panic!("result was not Invoke type")
+      _ => panic!("result was not Invoke type"),
     }
   }
 
   #[test]
   fn read_invoke_complicated_args() {
-    let json = "[\"invoke\", {\"id\":\"1\", \"args\": [\"we're\", [[\"wired\"],[\"high\"],[\"happy\"]]]}]";
+    let json = "[\"invoke\", {\"id\":\"1\", \"args\": [\"we're\", \
+                [[\"wired\"],[\"high\"],[\"happy\"]]]}]";
     let res = serde_json::from_str(json);
     println!("{:?}", res);
     match res.unwrap() {
       Request::Invoke(payload) => {
-        assert_eq!(payload, InvokeRequest {id: "1".to_owned(), args: vec!(
-              InvokeArgument::from_str("we're"),
-              InvokeArgument::Table(vec!(vec!("wired".to_owned()), vec!("high".to_owned()), vec!("happy".to_owned())))
-              )})
+        assert_eq!(payload,
+                   InvokeRequest {
+                     id: "1".to_owned(),
+                     args: vec![InvokeArgument::from_str("we're"),
+                                InvokeArgument::Table(vec![vec!["wired".to_owned()],
+                                                           vec!["high".to_owned()],
+                                                           vec!["happy".to_owned()]])],
+                   })
       },
-      _ => panic!("result was not Invoke type")
+      _ => panic!("result was not Invoke type"),
     }
   }
 
@@ -214,9 +232,9 @@ mod test {
     let res = serde_json::from_str(json);
     match res.unwrap() {
       Request::BeginScenario(payload) => {
-        assert_eq!(payload, BeginScenarioRequest {tags: Vec::new()})
+        assert_eq!(payload, BeginScenarioRequest { tags: Vec::new() })
       },
-      _ => panic!("result was not BeginScenario type")
+      _ => panic!("result was not BeginScenario type"),
     }
   }
 
@@ -226,9 +244,10 @@ mod test {
     let res = serde_json::from_str(json);
     match res.unwrap() {
       Request::BeginScenario(payload) => {
-        assert_eq!(payload, BeginScenarioRequest {tags: vec!("hello".to_owned())})
+        assert_eq!(payload,
+                   BeginScenarioRequest { tags: vec!["hello".to_owned()] })
       },
-      _ => panic!("result was not BeginScenario type")
+      _ => panic!("result was not BeginScenario type"),
     }
   }
 
@@ -237,10 +256,8 @@ mod test {
     let json = "[\"end_scenario\"]";
     let res = serde_json::from_str(json);
     match res.unwrap() {
-      Request::EndScenario(payload) => {
-        assert_eq!(payload, EndScenarioRequest {tags: Vec::new()})
-      },
-      _ => panic!("result was not EndScenario type")
+      Request::EndScenario(payload) => assert_eq!(payload, EndScenarioRequest { tags: Vec::new() }),
+      _ => panic!("result was not EndScenario type"),
     }
   }
 
@@ -250,21 +267,28 @@ mod test {
     let res = serde_json::from_str(json);
     match res.unwrap() {
       Request::EndScenario(payload) => {
-        assert_eq!(payload, EndScenarioRequest {tags: vec!("hello".to_owned())})
+        assert_eq!(payload,
+                   EndScenarioRequest { tags: vec!["hello".to_owned()] })
       },
-      _ => panic!("result was not EndScenario type")
+      _ => panic!("result was not EndScenario type"),
     }
   }
 
   #[test]
   fn read_snippet_text() {
-    let json = "[\"snippet_text\", {\"step_keyword\": \"Given\", \"multiline_arg_class\":\"\", \"step_name\":\"we're all wired\"}]";
+    let json = "[\"snippet_text\", {\"step_keyword\": \"Given\", \"multiline_arg_class\":\"\", \
+                \"step_name\":\"we're all wired\"}]";
     let res = serde_json::from_str(json);
     match res.unwrap() {
       Request::SnippetText(payload) => {
-        assert_eq!(payload, SnippetTextRequest {step_keyword: "Given".to_owned(), multiline_arg_class: "".to_owned(), step_name: "we're all wired".to_owned()})
+        assert_eq!(payload,
+                   SnippetTextRequest {
+                     step_keyword: "Given".to_owned(),
+                     multiline_arg_class: "".to_owned(),
+                     step_name: "we're all wired".to_owned(),
+                   })
       },
-      _ => panic!("result was not SnippetText type")
+      _ => panic!("result was not SnippetText type"),
     }
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,8 @@ pub mod state;
 /// External facing interface to other Gherkin implementations
 pub mod server;
 
-/// Coordinator logic between [server](server/index.html) and [state](state/index.html)
+/// Coordinator logic between [server](server/index.html) and
+/// [state](state/index.html)
 pub mod runner;
 
 /// Business logic for step registration and invoke argument destructuring
@@ -28,22 +29,21 @@ pub mod cucumber_regex;
 
 mod launcher;
 
-pub use launcher::{
-  start,
-  start_with_addr,
-  ruby_command
-};
+pub use launcher::{ruby_command, start, start_with_addr};
 
-pub use runner::{WorldRunner, CommandRunner};
+pub use runner::{CommandRunner, WorldRunner};
 pub use definitions::registration::CucumberRegistrar;
 pub use state::{Cucumber, SendableStep};
 pub use server::Server;
 pub use event::request::InvokeArgument;
-pub use event::response::InvokeResponse;
 
-/// Destructure a vector of [InvokeArgument](event/request/enum.InvokeArgument.html) into a tuple of values, or a bad [InvokeResponse](event/response/enum.InvokeResponse.html), similar to normal try!
+/// Destructure a vector of
+/// [InvokeArgument](event/request/enum.InvokeArgument.html) into a tuple of
+/// values, or a bad [InvokeResponse](event/response/enum.InvokeResponse.html),
+/// similar to normal try!
 ///
-/// Will either short circult return an InvokeArgument::Fail, describing either improper arg count
+/// Will either short circult return an InvokeArgument::Fail, describing either
+/// improper arg count
 /// or improper arg type, or will yield the tuple of values
 ///
 /// Reminder: Tuple of one value is represented as `(t,): (Type,)`
@@ -56,11 +56,10 @@ pub use event::response::InvokeResponse;
 ///
 /// use cucumber::{
 ///   InvokeArgument,
-///   InvokeResponse
 /// };
 ///
 /// fn main() {
-///   fn do_work() -> InvokeResponse {
+///   fn do_work() {
 ///     let args = vec![
 ///       InvokeArgument::from_str("1"),
 ///       InvokeArgument::from_str("2"),
@@ -68,18 +67,15 @@ pub use event::response::InvokeResponse;
 ///     ];
 ///     let (x, y, z): (u32, u32, bool) = try_destructure!(args);
 ///
-///     if x == 1 && y == 2 && z == false {
-///       InvokeResponse::Success
-///     } else {
-///       InvokeResponse::fail_from_str("Values did not match")
-///     }
+///     assert_eq!(x, 1);
+///     assert_eq!(y, 2);
+///     assert_eq!(z, false);
 ///   }
 /// }
 /// ```
 #[macro_export]
 macro_rules! try_destructure {
   ($r: ident) => ({
-    use $crate::event::response::InvokeResponse;
     use $crate::definitions::destructuring::{DestructurableSet, InvokeArgSetError};
 
     match $r.destructure_set() {
@@ -87,10 +83,10 @@ macro_rules! try_destructure {
       Err(error) => {
         match error {
           InvokeArgSetError::TypeMismatch {arg_idx} => {
-            return InvokeResponse::fail_from_str(&format!("Argument in position [{}] did not have the correct type or was unparseable", arg_idx))
+            panic!("Argument in position [{}] did not have the correct type or was unparseable", arg_idx)
           },
           InvokeArgSetError::ArgCountMismatch {expected, actual} => {
-            return InvokeResponse::fail_from_str(&format!("Expected [{}] arguments, but found [{}] in step definition", expected, actual))
+            panic!("Expected [{}] arguments, but found [{}] in step definition", expected, actual)
           }
         }
       }
@@ -98,7 +94,8 @@ macro_rules! try_destructure {
   })
 }
 
-/// Add a Given step to a [CucumberRegistrar](definitions/registration/trait.CucumberRegistrar.html)
+/// Add a Given step to a
+/// [CucumberRegistrar](definitions/registration/trait.CucumberRegistrar.html)
 ///
 /// # Example
 /// ```
@@ -106,7 +103,6 @@ macro_rules! try_destructure {
 /// extern crate cucumber;
 ///
 /// use cucumber::{
-///   InvokeResponse,
 ///   CucumberRegistrar,
 ///   Cucumber
 /// };
@@ -114,9 +110,9 @@ macro_rules! try_destructure {
 /// pub fn main () {
 ///   let mut cucumber: Cucumber<u32> = Cucumber::new();
 ///
-///   Given!(cucumber, "^I have (\\d+) coins$", |_, world: &mut u32, (coin_count,): (u32,)| {
+/// Given!(cucumber, "^I have (\\d+) coins$", |_, world: &mut u32,
+/// (coin_count,): (u32,)| {
 ///     *world = coin_count;
-///     InvokeResponse::Success
 ///   });
 /// }
 /// ```
@@ -131,7 +127,8 @@ macro_rules! Given {
   }}
 }
 
-/// Add a When step to a [CucumberRegistrar](definitions/registration/trait.CucumberRegistrar.html)
+/// Add a When step to a
+/// [CucumberRegistrar](definitions/registration/trait.CucumberRegistrar.html)
 ///
 /// # Example
 /// ```
@@ -139,7 +136,6 @@ macro_rules! Given {
 /// extern crate cucumber;
 ///
 /// use cucumber::{
-///   InvokeResponse,
 ///   CucumberRegistrar,
 ///   Cucumber
 /// };
@@ -147,12 +143,12 @@ macro_rules! Given {
 /// pub fn main () {
 ///   let mut cucumber: Cucumber<u32> = Cucumber::new();
 ///
-///   When!(cucumber, "^I spend (\\d+) coins$", |_, world: &mut u32, (coin_count,): (u32,)| {
+/// When!(cucumber, "^I spend (\\d+) coins$", |_, world: &mut u32,
+/// (coin_count,): (u32,)| {
 ///     if *world - coin_count < 0 {
-///       InvokeResponse::fail_from_str("Tried to spend more coins than were owned")
+///       panic!("Tried to spend more coins than were owned")
 ///     } else {
 ///       *world = *world - coin_count;
-///       InvokeResponse::Success
 ///     }
 ///   });
 /// }
@@ -168,7 +164,8 @@ macro_rules! When {
   }}
 }
 
-/// Add a Then step to a [CucumberRegistrar](definitions/registration/trait.CucumberRegistrar.html)
+/// Add a Then step to a
+/// [CucumberRegistrar](definitions/registration/trait.CucumberRegistrar.html)
 ///
 /// # Example
 /// ```
@@ -176,7 +173,6 @@ macro_rules! When {
 /// extern crate cucumber;
 ///
 /// use cucumber::{
-///   InvokeResponse,
 ///   CucumberRegistrar,
 ///   Cucumber
 /// };
@@ -184,8 +180,9 @@ macro_rules! When {
 /// pub fn main () {
 ///   let mut cucumber: Cucumber<u32> = Cucumber::new();
 ///
-///   Then!(cucumber, "^I have (\\d+) coins left$", |_, world: &mut u32, (coin_count,): (u32,)| {
-///     InvokeResponse::check_eq(*world, coin_count)
+/// Then!(cucumber, "^I have (\\d+) coins left$", |_, world: &mut u32,
+/// (coin_count,): (u32,)| {
+///     assert_eq!(*world, coin_count)
 ///   });
 /// }
 /// ```
@@ -199,4 +196,3 @@ macro_rules! Then {
     }))
   }}
 }
-

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,20 +1,26 @@
 use regex::Regex;
-use state::{Cucumber, Step};
-use event::request::Request;
-use event::response::{Response, StepMatchesResponse};
-use definitions::registration::CucumberRegistrar;
+use state::Cucumber;
+use event::request::{InvokeArgument, Request};
+use event::response::{InvokeResponse, Response, StepMatchesResponse};
+use definitions::registration::{CucumberRegistrar, SimpleStep};
+use std::panic::{self, AssertUnwindSafe};
 
 use std::str::FromStr;
 
 /// The step runner for [Cucumber state](../state/struct.Cucumber.html)
 ///
 /// The runner stands in for the Cucumber instance and provides an interface for
-/// [Request](../event/request/enum.Request.html) events to be translated into state changes and
-/// step invocations, along with a [Response](../event/response/enum.Response.html). These are typically supplied by a running
-/// [Server](../server/struct.Server.html), but may be supplied by a native Gherkin implementation
+/// [Request](../event/request/enum.Request.html) events to be translated into
+/// state changes and
+/// step invocations, along with a
+/// [Response](../event/response/enum.Response.html). These are typically
+/// supplied by a running
+/// [Server](../server/struct.Server.html), but may be supplied by a native
+/// Gherkin implementation
 /// later.
 ///
-/// Typically this struct will only be instantiated by the user, and then passed to a Server to
+/// Typically this struct will only be instantiated by the user, and then
+/// passed to a Server to
 /// maintain.
 ///
 #[allow(dead_code)]
@@ -23,7 +29,7 @@ pub struct WorldRunner<World> {
   world: World,
 }
 
-impl <World> WorldRunner<World> {
+impl<World> WorldRunner<World> {
   #[allow(dead_code)]
   pub fn new(world: World) -> WorldRunner<World> {
     WorldRunner {
@@ -33,20 +39,22 @@ impl <World> WorldRunner<World> {
   }
 }
 
-/// An interface for implementers that can consume a [Request](../event/request/enum.Request.html) and yield a [Response](../event/response/enum.Response.html)
+/// An interface for implementers that can consume a
+/// [Request](../event/request/enum.Request.html) and yield a
+/// [Response](../event/response/enum.Response.html)
 ///
 /// This generally refers to [WorldRunner](./struct.WorldRunner.html)
 pub trait CommandRunner {
   fn execute_cmd(&mut self, req: Request) -> Response;
 }
 
-impl <T: Fn(Request) -> Response> CommandRunner for T {
+impl<T: Fn(Request) -> Response> CommandRunner for T {
   fn execute_cmd(&mut self, req: Request) -> Response {
     self(req)
   }
 }
 
-impl <World> CommandRunner for WorldRunner<World> {
+impl<World> CommandRunner for WorldRunner<World> {
   fn execute_cmd(&mut self, req: Request) -> Response {
     match req {
       Request::BeginScenario(params) => {
@@ -54,8 +62,10 @@ impl <World> CommandRunner for WorldRunner<World> {
         Response::BeginScenario
       },
       Request::Invoke(params) => {
-        let step = self.cuke.step(u32::from_str(&params.id).unwrap()).unwrap();
-        Response::Invoke(step(&self.cuke, &mut self.world, params.args))
+        let step = self.cuke
+          .step(u32::from_str(&params.id).unwrap())
+          .unwrap();
+        Response::Invoke(invoke_to_response(step, &self.cuke, &mut self.world, params.args))
       },
       Request::StepMatches(params) => {
         let matches = self.cuke.find_match(&params.name_to_match);
@@ -71,45 +81,58 @@ impl <World> CommandRunner for WorldRunner<World> {
       },
       // TODO: For some reason, cucumber prints the ruby snippet too. Fix that
       Request::SnippetText(params) => {
-        let text =
-          format!("  // In a step registration block where cuke: &mut CucumberRegistrar<YourWorld>\
-          \n  use cucumber::InvokeResponse;\
-          \n  use cucumber::helpers::r;\
-          \n  {}!(cuke, r(\"^{}$\"), Box::new(move |_, _, _| {{\
-          \n    InvokeResponse::pending(\"TODO\")\
-          \n  }}));\
-          ", params.step_keyword, params.step_name);
+        let text = format!("  // In a step registration block where cuke: &mut \
+                            CucumberRegistrar<YourWorld>\n  use cucumber::InvokeResponse;\n  use \
+                            cucumber::helpers::r;\n  {}!(cuke, r(\"^{}$\"), Box::new(move |c, _, \
+                            _| {{\n    c.pending(\"TODO\")\n  }}));",
+                           params.step_keyword,
+                           params.step_name);
 
         Response::SnippetText(text)
-      }
+      },
     }
   }
 }
 
-impl <World> CucumberRegistrar<World> for WorldRunner<World> {
-  fn given(&mut self, file: &str, line: u32, regex: Regex, step: Step<World>) {
-    self.cuke.given(file, line, regex, wrap(step))
+impl<World> CucumberRegistrar<World> for WorldRunner<World> {
+  fn given(&mut self, file: &str, line: u32, regex: Regex, step: SimpleStep<World>) {
+    self.cuke.given(file, line, regex, step)
   }
 
   fn when(&mut self, file: &str, line: u32, regex: Regex, step: SimpleStep<World>) {
-    self.cuke.when(file, line, regex, wrap(step))
+    self.cuke.when(file, line, regex, step)
   }
 
   fn then(&mut self, file: &str, line: u32, regex: Regex, step: SimpleStep<World>) {
-    self.cuke.then(file, line, regex, wrap(step))
+    self.cuke.then(file, line, regex, step)
   }
 }
 
-// A "simpler" api-level step. Panic to fail.
-type SimpleStep<World> = Box<Send + Fn(&Cucumber<World>, &mut World, Vec<InvokeArgument>)>
-
-fn wrap<World>(test_body: SimpleStep<World>) -> Step<World> {
-  Box::new(|cuke, world, args| {
-    let result = panic::catch_unwind(|| test_body(cuke, world, args));
-    match result {
-      Ok(()) => InvokeResponse::Success,
-      Err("!!Cucumber secret pending error!!") => InvokeResponse::Pending,
-      Err(err) => InvokeResponse::fail_from_str(err)
-    }
-  })
+pub fn invoke_to_response<World>(test_body: &SimpleStep<World>,
+                                 cuke: &Cucumber<World>,
+                                 world: &mut World,
+                                 args: Vec<InvokeArgument>)
+                                 -> InvokeResponse {
+  let result = panic::catch_unwind(AssertUnwindSafe(|| test_body(cuke, world, args)));
+  match result {
+    Ok(()) => InvokeResponse::Success,
+    Err(err) => {
+      // Yoinked from rustc libstd, with InvokeResponse added as a possible cast
+      let msg = match err.downcast_ref::<&'static str>() {
+        Some(s) => *s,
+        None => {
+          match err.downcast_ref::<String>() {
+            Some(s) => &s[..],
+            None => {
+              match err.downcast_ref::<InvokeResponse>() {
+                Some(s) => return s.clone(),
+                None => "Box<Any>",
+              }
+            },
+          }
+        },
+      };
+      InvokeResponse::fail_from_str(msg)
+    },
+  }
 }


### PR DESCRIPTION
This is only the runner.rs file (because I'm editing from github). It provides a simpler panic-based test api, and hides the invoke response internals.
