### PR TITLE
Windows & 0.0.0.0

### DIFF
--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -42,12 +42,7 @@ use std::env;
 /// ```
 ///
 pub fn start<W: Send + 'static>(world: W, register_fns: &[&Fn(&mut CucumberRegistrar<W>)]) {
-  let addr = if cfg!(target_os = "windows") {
-    "127.0.0.1:7878"
-  } else {
-    "0.0.0.0:7878"
-  };
-  start_with_addr(addr, world, register_fns)
+  start_with_addr("127.0.0.1:7878", world, register_fns)
 }
 
 /// Start a Cucumber server, with an ip and port, see the [`start()

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -43,9 +43,9 @@ use std::env;
 ///
 pub fn start<W: Send + 'static>(world: W, register_fns: &[&Fn(&mut CucumberRegistrar<W>)]) {
   let addr = if cfg!(target_os = "windows") {
-    "127.0.0.1:1234"
+    "127.0.0.1:7879"
   } else {
-    "0.0.0.0:1234"
+    "0.0.0.0:7879"
   };
   start_with_addr(addr, world, register_fns)
 }

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -43,9 +43,9 @@ use std::env;
 ///
 pub fn start<W: Send + 'static>(world: W, register_fns: &[&Fn(&mut CucumberRegistrar<W>)]) {
   let addr = if cfg!(target_os = "windows") {
-    "127.0.0.1:7879"
+    "127.0.0.1:7878"
   } else {
-    "0.0.0.0:7879"
+    "0.0.0.0:7878"
   };
   start_with_addr(addr, world, register_fns)
 }

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -42,7 +42,12 @@ use std::env;
 /// ```
 ///
 pub fn start<W: Send + 'static>(world: W, register_fns: &[&Fn(&mut CucumberRegistrar<W>)]) {
-  start_with_addr("0.0.0.0:7878", world, register_fns)
+  let addr = if cfg!(target_os = "windows") {
+    "127.0.0.1:1234"
+  } else {
+    "0.0.0.0:1234"
+  };
+  start_with_addr(addr, world, register_fns)
 }
 
 /// Start a Cucumber server, with an ip and port, see the [`start()

--- a/src/server.rs
+++ b/src/server.rs
@@ -162,8 +162,13 @@ mod test {
   #[test]
   fn it_makes_a_server() {
     let server = Server::new(|_| Response::BeginScenario);
-    let (handle, stop_tx) = server.start(Some("0.0.0.0:1234"));
-    let _ = TcpStream::connect("0.0.0.0:1234").unwrap();
+    let addr = if cfg!(target_os = "windows") {
+      "127.0.0.1:1234"
+    } else {
+      "0.0.0.0:1234"
+    };
+    let (handle, stop_tx) = server.start(Some(addr));
+    let _ = TcpStream::connect(addr).unwrap();
 
     stop_tx.send(()).unwrap();
     handle.join().unwrap();
@@ -180,8 +185,13 @@ mod test {
         Request::SnippetText(_) => Response::SnippetText("Snippet".to_owned()),
       }
     });
-    let (handle, stop_tx) = server.start(Some("0.0.0.0:1235"));
-    let mut stream = TcpStream::connect("0.0.0.0:1235").unwrap();
+    let addr = if cfg!(target_os = "windows") {
+      "127.0.0.1:1235"
+    } else {
+      "0.0.0.0:1235"
+    };
+    let (handle, stop_tx) = server.start(Some(addr));
+    let mut stream = TcpStream::connect(addr).unwrap();
 
     {
       stream.write(b"[\"begin_scenario\"]\n").unwrap();

--- a/src/server.rs
+++ b/src/server.rs
@@ -93,7 +93,7 @@ impl<R: CommandRunner + Send> Server<R> {
   pub fn start(mut self, addr: Option<&'static str>) -> (JoinHandle<()>, Sender<()>)
     where R: 'static
   {
-    let addr = addr.unwrap_or("0.0.0.0:7878");
+    let addr = addr.unwrap_or("127.0.0.1:7878");
     let (stop_tx, stop_rx) = channel();
     let main_barrier = Arc::new(Barrier::new(2));
     let tcp_barrier = main_barrier.clone();
@@ -162,13 +162,8 @@ mod test {
   #[test]
   fn it_makes_a_server() {
     let server = Server::new(|_| Response::BeginScenario);
-    let addr = if cfg!(target_os = "windows") {
-      "127.0.0.1:1234"
-    } else {
-      "0.0.0.0:1234"
-    };
-    let (handle, stop_tx) = server.start(Some(addr));
-    let _ = TcpStream::connect(addr).unwrap();
+    let (handle, stop_tx) = server.start(Some("127.0.0.1:1234"));
+    let _ = TcpStream::connect("127.0.0.1:1234").unwrap();
 
     stop_tx.send(()).unwrap();
     handle.join().unwrap();
@@ -185,13 +180,8 @@ mod test {
         Request::SnippetText(_) => Response::SnippetText("Snippet".to_owned()),
       }
     });
-    let addr = if cfg!(target_os = "windows") {
-      "127.0.0.1:1235"
-    } else {
-      "0.0.0.0:1235"
-    };
-    let (handle, stop_tx) = server.start(Some(addr));
-    let mut stream = TcpStream::connect(addr).unwrap();
+    let (handle, stop_tx) = server.start(Some("127.0.0.1:1235"));
+    let mut stream = TcpStream::connect("127.0.0.1:1235").unwrap();
 
     {
       stream.write(b"[\"begin_scenario\"]\n").unwrap();


### PR DESCRIPTION
Apparently Windows does not like 0.0.0.0.

>  ---- server::test::it_relays_commands_to_the_runner stdout ----
>     thread 'server::test::it_relays_commands_to_the_runner' panicked at 'called Result::unwrap() on an Err value: Error { repr: Os { code: 10049, message: "The requested address is not valid in its context." } }', ../src/libcore\result.rs:788
