### PR TITLE
Added must_use attribute

### DIFF
--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 use std::env;
 
 #[derive(Default)]
+#[must_use = "CucumberConfig has to be consumed by start method!"]
 pub struct CucumberConfig<'a, W: Send + 'static> {
   world: W,
   addr: &'static str,


### PR DESCRIPTION
Added _#[must_use]_ attribute to CucumberConfig. 
Missing start calls should be easier to spot now. 
Probably could have spotted the issue in #38
