### PR TITLE
Fix compilation error about inference

### DIFF
--- a/examples/calculator/features/step_definitions/calculator_steps.rs
+++ b/examples/calculator/features/step_definitions/calculator_steps.rs
@@ -8,17 +8,17 @@ pub fn register_steps(c: &mut CucumberRegistrar<CalculatorWorld>) {
 
   Given!(c,
          "^a clear calculator$",
-         |_, world: &mut CalculatorWorld, _| {
+         |_, world: &mut CalculatorWorld, ()| {
            world.calculator.clear();
          });
 
-  When!(c, "^I begin adding$", |_, world: &mut CalculatorWorld, _| {
+  When!(c, "^I begin adding$", |_, world: &mut CalculatorWorld, ()| {
     world.last_response = Some(world.calculator.push_command(CalculatorCommand::Add));
   });
 
   When!(c,
         "^I begin subtracting$",
-        |_, world: &mut CalculatorWorld, _| {
+        |_, world: &mut CalculatorWorld, ()| {
           world.last_response = Some(world.calculator.push_command(CalculatorCommand::Minus));
         });
 

--- a/features/feature_features/calling_steps.feature
+++ b/features/feature_features/calling_steps.feature
@@ -4,11 +4,11 @@ Feature: Calling steps within steps
     Given a project if I don't already have one
     And the steps
       """
-        When!(c, "^I get invoked indirectly$", |_, _, _| {
+        When!(c, "^I get invoked indirectly$", |_, _, ()| {
           panic!("Indirect step got invoked!");
         });
 
-        When!(c, "^I invoke a step indirectly$", |cuke: &Cucumber<u32>, world: &mut u32, _| {
+        When!(c, "^I invoke a step indirectly$", |cuke: &Cucumber<u32>, world: &mut u32, ()| {
           cuke.invoke("I get invoked indirectly", world, None);
         });
       """

--- a/features/feature_features/executing.feature
+++ b/features/feature_features/executing.feature
@@ -4,24 +4,24 @@ Feature: Executing Features
     Given a project if I don't already have one
     And the steps
       """
-        Given!(c, "^a passing given step$", |_, _, _| {
+        Given!(c, "^a passing given step$", |_, _, ()| {
         });
 
-        When!(c, "^a passing when step$", |_, _, _| {
+        When!(c, "^a passing when step$", |_, _, ()| {
         });
 
-        Then!(c, "^a passing then step$", |_, _, _| {
+        Then!(c, "^a passing then step$", |_, _, ()| {
         });
 
-        Given!(c, "^a failing given step$", |_, _, _| {
+        Given!(c, "^a failing given step$", |_, _, ()| {
           panic!("Given Step Failed");
         });
 
-        When!(c, "^a failing when step$", |_, _, _| {
+        When!(c, "^a failing when step$", |_, _, ()| {
           panic!("When Step Failed");
         });
 
-        Then!(c, "^a failing then step$", |_, _, _| {
+        Then!(c, "^a failing then step$", |_, _, ()| {
           panic!("Then Step Failed");
         });
       """

--- a/features/feature_features/explicit_failures.feature
+++ b/features/feature_features/explicit_failures.feature
@@ -3,7 +3,7 @@ Feature: Explicit failures
     Given a project if I don't already have one
     And the steps
       """
-        Given!(c, "^an ordinary step$", |c: &Cucumber<u32>, _, _| {
+        Given!(c, "^an ordinary step$", |c: &Cucumber<u32>, _, ()| {
           c.fail("I just don't want this step to pass");
         });
       """

--- a/features/feature_features/explicit_successes.feature
+++ b/features/feature_features/explicit_successes.feature
@@ -3,7 +3,7 @@ Feature: Explicit (early) success
     Given a project if I don't already have one
     And the steps
       """
-        Given!(c, "^an ordinary step$", |c: &Cucumber<u32>, _, _| {
+        Given!(c, "^an ordinary step$", |c: &Cucumber<u32>, _, ()| {
           c.succeed_immediately();
           panic!("Unreachable panic!");
         });

--- a/features/feature_features/passing_arguments.feature
+++ b/features/feature_features/passing_arguments.feature
@@ -4,11 +4,11 @@ Feature: Invalid argument types
     Given a project if I don't already have one
     And the steps
       """
-        Given!(c, "^I just explode$", |c: &Cucumber<u32>, _, _| {
+        Given!(c, "^I just explode$", |c: &Cucumber<u32>, _, ()| {
           c.fail("Should not have invoked this scenario");
         });
 
-        Given!(c, "^I run normally$", |_, _, _| {
+        Given!(c, "^I run normally$", |_, _, ()| {
         });
       """
     Then the project compiles

--- a/features/feature_features/pending_steps.feature
+++ b/features/feature_features/pending_steps.feature
@@ -4,7 +4,7 @@ Feature: Pending Steps
     Given a project if I don't already have one
     And the steps
       """
-      Given!(c, "^a pending step$", |c: &Cucumber<u32>, _, _| {
+      Given!(c, "^a pending step$", |c: &Cucumber<u32>, _, ()| {
           c.pending("Test step is pending");
         });
       """

--- a/features/step_definitions/project_steps.rs
+++ b/features/step_definitions/project_steps.rs
@@ -4,7 +4,7 @@ use support::fs;
 
 #[allow(dead_code)]
 pub fn register_steps(c: &mut CucumberRegistrar<CucumberWorld>) {
-  Given!(c, "^a project$", |_, world: &mut CucumberWorld, _| {
+  Given!(c, "^a project$", |_, world: &mut CucumberWorld, ()| {
     match fs::create_project() {
       Ok(current_project) => {
         world.current_project = Some(current_project);
@@ -15,7 +15,7 @@ pub fn register_steps(c: &mut CucumberRegistrar<CucumberWorld>) {
 
   Given!(c,
          "^a project if I don't already have one$",
-         |cuke: &Cucumber<CucumberWorld>, world: &mut CucumberWorld, _| {
+         |cuke: &Cucumber<CucumberWorld>, world: &mut CucumberWorld, ()| {
            match world.current_project {
              None => cuke.invoke("a project", world, None),
              _ => {},
@@ -35,7 +35,7 @@ pub fn register_steps(c: &mut CucumberRegistrar<CucumberWorld>) {
 
   Then!(c,
         "^the project compiles$",
-        |_, world: &mut CucumberWorld, _| {
+        |_, world: &mut CucumberWorld, ()| {
     match world.current_project {
       None => return panic!("There was no project to compile"),
       Some(ref mut project) => {
@@ -71,14 +71,14 @@ pub fn register_steps(c: &mut CucumberRegistrar<CucumberWorld>) {
 
   Then!(c,
         "^the feature passes with no undefined steps$",
-        |cuke: &Cucumber<CucumberWorld>, world: &mut CucumberWorld, _| {
+        |cuke: &Cucumber<CucumberWorld>, world: &mut CucumberWorld, ()| {
           cuke.invoke("the feature passes", world, None);
           cuke.invoke("the feature reports no undefined steps", world, None);
         });
 
   Then!(c,
         "^the feature passes$",
-        |_, world: &mut CucumberWorld, _| {
+        |_, world: &mut CucumberWorld, ()| {
     match world.execute_result {
       None => panic!("Expected there to be an execute result but there wasn't one"),
       Some(Err(ref err)) => panic!("Expected scenario to pass but it failed with {}", err),
@@ -98,7 +98,7 @@ pub fn register_steps(c: &mut CucumberRegistrar<CucumberWorld>) {
 
   Then!(c,
         "^the feature reports an undefined step$",
-        |_, world: &mut CucumberWorld, _| {
+        |_, world: &mut CucumberWorld, ()| {
     match world.execute_result {
       None => panic!("Expected there to be an execute result but there wasn't one"),
       Some(Err(_)) => {
@@ -110,7 +110,7 @@ pub fn register_steps(c: &mut CucumberRegistrar<CucumberWorld>) {
 
   Then!(c,
         "^the feature reports no undefined steps$",
-        |_, world: &mut CucumberWorld, _| {
+        |_, world: &mut CucumberWorld, ()| {
     match world.execute_result {
       None => panic!("Expected there to be an execute result but there wasn't one"),
       Some(Err(_)) => {
@@ -122,7 +122,7 @@ pub fn register_steps(c: &mut CucumberRegistrar<CucumberWorld>) {
 
   Then!(c,
         "^the feature reports a pending step$",
-        |_, world: &mut CucumberWorld, _| {
+        |_, world: &mut CucumberWorld, ()| {
     match world.execute_result {
       None => panic!("Expected there to be an execute result but there wasn't one"),
       Some(Err(_)) => {


### PR DESCRIPTION
Instead of asking for anything, explicitly ask for nothing.

This is for #50.

I tried playing with macros and with traits with the intention to being able to accept closures *without* the last argument, or even better, passing the arguments as separate ones instead of a tuple. But after few hours of failures I gave up.

However, I noticed the parameters can be arbitrary patterns, so it is possible to ask for `()` instead of `_: ()`.

It now compiles, but fails the tests, possibly due to incompatible cucumber version. I'm going to put that into a separate issue.